### PR TITLE
fix(frontend): Handle paginated API responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,18 +50,37 @@ clouseau/
 └── scripts/          # Utility scripts
 ```
 
-## Makefile Commands
+## Development Commands
+
+**IMPORTANT: Always use `make` commands instead of running npm/uv directly.**
+
+### Running the Application
+
+| Command | Description | URL |
+|---------|-------------|-----|
+| `make run` | Start both backend + frontend | Backend: http://localhost:8000, Frontend: http://localhost:3000 |
+| `make run-backend` | Start backend API server only | http://localhost:8000 (API docs: /docs) |
+| `make run-frontend` | Start frontend dev server only | http://localhost:3000 |
+
+### Testing & Building
 
 | Command | Description |
 |---------|-------------|
 | `make test` | Run all tests |
 | `make test-backend` | Run backend tests with coverage |
 | `make test-frontend` | Run frontend tests |
-| `make build` | Build frontend and CLI |
-| `make run-backend` | Start backend dev server (port 8000) |
-| `make run-frontend` | Start frontend dev server (port 5173) |
+| `make coverage-frontend` | Run frontend tests with coverage report |
+| `make build` | Build frontend and CLI for production |
+| `make check` | Full CI check (build + lint + test) |
+
+### Utilities
+
+| Command | Description |
+|---------|-------------|
 | `make sync` | Sync to Dropbox |
 | `make backup` | Create dated backup |
+| `make clean` | Remove build artifacts and caches |
+| `make help` | Show all available commands |
 
 ## File Locations
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ help:
 	@echo "Run (Development Servers):"
 	@echo "  make run              - Run backend + frontend together"
 	@echo "  make run-backend      - Run backend API server (port 8000)"
-	@echo "  make run-frontend     - Run frontend dev server (port 5173)"
+	@echo "  make run-frontend     - Run frontend dev server (port 3000)"
 	@echo "  make run-cli          - Run CLI in dev mode"
 	@echo ""
 	@echo "Sync/Backup:"
@@ -250,7 +250,7 @@ coverage-cli:
 run:
 	@echo "Starting backend and frontend..."
 	@echo "Backend: http://localhost:8000"
-	@echo "Frontend: http://localhost:5173"
+	@echo "Frontend: http://localhost:3000"
 	@echo "Press Ctrl+C to stop"
 	@echo ""
 	@trap 'kill 0' INT; \
@@ -267,7 +267,7 @@ run-backend:
 
 run-frontend:
 	@echo "Starting frontend dev server..."
-	@echo "URL: http://localhost:5173"
+	@echo "URL: http://localhost:3000"
 	@echo ""
 	@if [ ! -d "frontend/node_modules" ]; then \
 		echo "Error: Run 'make setup-frontend' first"; \

--- a/frontend/src/services/conversations.ts
+++ b/frontend/src/services/conversations.ts
@@ -1,13 +1,13 @@
 // Conversations API service
 
 import type { Conversation } from '../types';
-import type { ApiConversation } from '../types/api';
+import type { ApiConversation, ApiPaginatedResponse } from '../types/api';
 import { fetchApi } from './api';
 import { transformConversation } from './transforms';
 
 export async function getConversations(sessionId: string): Promise<Conversation[]> {
-  const response = await fetchApi<ApiConversation[]>(`/sessions/${sessionId}/conversations`);
-  return response.map(transformConversation);
+  const response = await fetchApi<ApiPaginatedResponse<ApiConversation>>(`/conversations/by-session/${sessionId}`);
+  return response.items.map(transformConversation);
 }
 
 export async function getConversation(id: string): Promise<Conversation> {

--- a/frontend/src/services/exchanges.ts
+++ b/frontend/src/services/exchanges.ts
@@ -1,13 +1,13 @@
 // Exchanges API service
 
 import type { Exchange } from '../types';
-import type { ApiExchange } from '../types/api';
+import type { ApiExchange, ApiPaginatedResponse } from '../types/api';
 import { fetchApi } from './api';
 import { transformExchange } from './transforms';
 
 export async function getExchanges(conversationId: string): Promise<Exchange[]> {
-  const response = await fetchApi<ApiExchange[]>(`/conversations/${conversationId}/exchanges`);
-  return response.map(transformExchange);
+  const response = await fetchApi<ApiPaginatedResponse<ApiExchange>>(`/exchanges/by-conversation/${conversationId}`);
+  return response.items.map(transformExchange);
 }
 
 export async function getExchange(id: string): Promise<Exchange> {

--- a/frontend/src/services/sessions.ts
+++ b/frontend/src/services/sessions.ts
@@ -1,13 +1,13 @@
 // Sessions API service
 
 import type { Session } from '../types';
-import type { ApiSession } from '../types/api';
+import type { ApiSession, ApiPaginatedResponse } from '../types/api';
 import { fetchApi } from './api';
 import { transformSession } from './transforms';
 
 export async function getSessions(): Promise<Session[]> {
-  const response = await fetchApi<ApiSession[]>('/sessions');
-  return response.map(transformSession);
+  const response = await fetchApi<ApiPaginatedResponse<ApiSession>>('/sessions');
+  return response.items.map(transformSession);
 }
 
 export async function getSession(id: string): Promise<Session> {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -26,3 +26,11 @@ export interface ApiExchange {
   output_tokens: number | null;
   created_at: string;
 }
+
+// Paginated response wrapper
+export interface ApiPaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+}

--- a/frontend/tests/unit/services/conversations.test.ts
+++ b/frontend/tests/unit/services/conversations.test.ts
@@ -14,27 +14,32 @@ describe('conversations service', () => {
   });
 
   describe('getConversations', () => {
-    it('fetches and transforms conversations for a session', async () => {
-      vi.mocked(api.fetchApi).mockResolvedValue([
-        {
-          id: 10,
-          session_id: 1,
-          title: 'Conversation 1',
-          created_at: '2024-01-15T10:00:00Z',
-          updated_at: '2024-01-15T11:00:00Z',
-        },
-        {
-          id: 11,
-          session_id: 1,
-          title: 'Conversation 2',
-          created_at: '2024-01-16T10:00:00Z',
-          updated_at: '2024-01-16T11:00:00Z',
-        },
-      ]);
+    it('fetches and transforms conversations for a session from paginated response', async () => {
+      vi.mocked(api.fetchApi).mockResolvedValue({
+        items: [
+          {
+            id: 10,
+            session_id: 1,
+            title: 'Conversation 1',
+            created_at: '2024-01-15T10:00:00Z',
+            updated_at: '2024-01-15T11:00:00Z',
+          },
+          {
+            id: 11,
+            session_id: 1,
+            title: 'Conversation 2',
+            created_at: '2024-01-16T10:00:00Z',
+            updated_at: '2024-01-16T11:00:00Z',
+          },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 20,
+      });
 
       const result = await getConversations('1');
 
-      expect(api.fetchApi).toHaveBeenCalledWith('/sessions/1/conversations');
+      expect(api.fetchApi).toHaveBeenCalledWith('/conversations/by-session/1');
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe('10');
       expect(result[0].sessionId).toBe('1');

--- a/frontend/tests/unit/services/exchanges.test.ts
+++ b/frontend/tests/unit/services/exchanges.test.ts
@@ -14,33 +14,38 @@ describe('exchanges service', () => {
   });
 
   describe('getExchanges', () => {
-    it('fetches and transforms exchanges for a conversation', async () => {
-      vi.mocked(api.fetchApi).mockResolvedValue([
-        {
-          id: 100,
-          conversation_id: 10,
-          user_message: 'Hello',
-          assistant_message: 'Hi there',
-          model: 'gpt-4',
-          input_tokens: 50,
-          output_tokens: 30,
-          created_at: '2024-01-15T10:00:00Z',
-        },
-        {
-          id: 101,
-          conversation_id: 10,
-          user_message: 'How are you?',
-          assistant_message: 'I am doing well',
-          model: null,
-          input_tokens: null,
-          output_tokens: null,
-          created_at: '2024-01-15T10:01:00Z',
-        },
-      ]);
+    it('fetches and transforms exchanges for a conversation from paginated response', async () => {
+      vi.mocked(api.fetchApi).mockResolvedValue({
+        items: [
+          {
+            id: 100,
+            conversation_id: 10,
+            user_message: 'Hello',
+            assistant_message: 'Hi there',
+            model: 'gpt-4',
+            input_tokens: 50,
+            output_tokens: 30,
+            created_at: '2024-01-15T10:00:00Z',
+          },
+          {
+            id: 101,
+            conversation_id: 10,
+            user_message: 'How are you?',
+            assistant_message: 'I am doing well',
+            model: null,
+            input_tokens: null,
+            output_tokens: null,
+            created_at: '2024-01-15T10:01:00Z',
+          },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 50,
+      });
 
       const result = await getExchanges('10');
 
-      expect(api.fetchApi).toHaveBeenCalledWith('/conversations/10/exchanges');
+      expect(api.fetchApi).toHaveBeenCalledWith('/exchanges/by-conversation/10');
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe('100');
       expect(result[0].conversationId).toBe('10');

--- a/frontend/tests/unit/services/sessions.test.ts
+++ b/frontend/tests/unit/services/sessions.test.ts
@@ -14,23 +14,28 @@ describe('sessions service', () => {
   });
 
   describe('getSessions', () => {
-    it('fetches and transforms sessions', async () => {
-      vi.mocked(api.fetchApi).mockResolvedValue([
-        {
-          id: 1,
-          name: 'Session 1',
-          description: 'First session',
-          created_at: '2024-01-15T10:00:00Z',
-          updated_at: '2024-01-15T11:00:00Z',
-        },
-        {
-          id: 2,
-          name: 'Session 2',
-          description: null,
-          created_at: '2024-01-16T10:00:00Z',
-          updated_at: '2024-01-16T11:00:00Z',
-        },
-      ]);
+    it('fetches and transforms sessions from paginated response', async () => {
+      vi.mocked(api.fetchApi).mockResolvedValue({
+        items: [
+          {
+            id: 1,
+            name: 'Session 1',
+            description: 'First session',
+            created_at: '2024-01-15T10:00:00Z',
+            updated_at: '2024-01-15T11:00:00Z',
+          },
+          {
+            id: 2,
+            name: 'Session 2',
+            description: null,
+            created_at: '2024-01-16T10:00:00Z',
+            updated_at: '2024-01-16T11:00:00Z',
+          },
+        ],
+        total: 2,
+        page: 1,
+        page_size: 20,
+      });
 
       const result = await getSessions();
 


### PR DESCRIPTION
## Summary
- Fixed "response.map is not a function" error in SessionBrowser
- Backend returns paginated responses `{items, total, page, page_size}` but frontend expected arrays
- Added `ApiPaginatedResponse<T>` type and updated services to extract `items`
- Fixed endpoint URLs to match backend routes

## Test plan
- [x] All 65 frontend tests pass
- [ ] Manual testing: Start backend and frontend, verify sessions load without errors
- [ ] Verify conversations display when clicking a session
- [ ] Verify exchanges display in chat when clicking a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)